### PR TITLE
fix: n-days sorting

### DIFF
--- a/src/components/Monthly/DayCell.tsx
+++ b/src/components/Monthly/DayCell.tsx
@@ -20,7 +20,7 @@ const DayCell = ({
   onMoreButtonClick,
 }: DayCellProps) => {
   const { onClick, onDoubleClick } = useDoubleClick({ onClick: onDateClick, onDoubleClick: onDateDblClick });
-  const moreButtonNum = events.length - maxEvents;
+  const moreButtonNum = events.filter(event => event).length - maxEvents;
 
   return (
     <S.DayCellContainer

--- a/src/components/Monthly/DayCellContent.tsx
+++ b/src/components/Monthly/DayCellContent.tsx
@@ -19,7 +19,7 @@ const DayCellContent = ({
       {events
         .slice(0, maxEvents)
         .map((event, eventIndex) =>
-          event.startDate.hasSame(date, 'day') || index === 0 ? (
+          event && (event.startDate.hasSame(date, 'day') || index === 0) ? (
             <EventBar
               key={`${date.toISODate()}-${eventIndex}`}
               date={date}

--- a/src/components/MoreButton/MorePopover.tsx
+++ b/src/components/MoreButton/MorePopover.tsx
@@ -26,9 +26,7 @@ const MorePopover = ({ open, anchorEl, onClose, date, events }: Props) => {
     >
       <S.PopoverHeader>{date.toFormat('LL/dd (cccc)')}</S.PopoverHeader>
       <S.PopoverContent>
-        {events.map(event => (
-          <S.EventBar $color={event.color}>{event.title}</S.EventBar>
-        ))}
+        {events.map(event => event && <S.EventBar $color={event.color}>{event.title}</S.EventBar>)}
       </S.PopoverContent>
     </Popover>
   );

--- a/src/constants/interfaces.ts
+++ b/src/constants/interfaces.ts
@@ -12,6 +12,7 @@ export interface EventInput {
   end: DateLike;
   allDay?: boolean;
   color?: string;
+  [key: string]: unknown;
 }
 
 export interface MoreButtonParams {
@@ -29,7 +30,7 @@ export interface CalendarProps {
   width?: string | number;
   height?: string | number;
   firstDay?: WeekdayNumbers;
-  order?: (keyof EventInput | `-${keyof EventInput}`)[];
+  order?: string[];
   eventHeight?: number;
   maxEvents?: number;
   moreButtonContent?: (num: number) => string | JSX.Element;
@@ -40,7 +41,8 @@ export interface HeaderProps {
   firstDay?: WeekdayNumbers;
 }
 
-export interface DayCellProps extends Omit<CalendarProps, 'width' | 'height' | 'firstDay' | 'order'> {
+export interface DayCellProps extends Omit<CalendarProps, 'events' | 'width' | 'height' | 'firstDay' | 'order'> {
+  events: (EventModel | undefined)[];
   date: DateTime;
   index: number;
   eventHeight: number;

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -26,22 +26,6 @@ export const sortByDate = (events: EventModel[]) => {
   return events.sort((a, b) => a.startDate.toMillis() - b.startDate.toMillis());
 };
 
-export const groupByDate = (events: EventModel[]) => {
-  const eventMap = new Map<string, EventModel[]>();
-  events.forEach(event => {
-    const date = event.startDate.toISODate();
-    if (!date) return;
-    eventMap.set(date, eventMap.has(date) ? [...eventMap.get(date)!, event] : [event]);
-  });
-  return eventMap;
-};
-
-export const sortByOrder = (eventMap: Map<string, EventModel[]>, order: string[]) => {
-  return !order.length
-    ? eventMap
-    : new Map(Array.from(eventMap.entries()).map(([key, value]) => [key, value.sort(compareOrder(0, order))]));
-};
-
 export const compareOrder =
   (index: number, order: string[]) =>
   (a: EventModel, b: EventModel): number => {

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -42,14 +42,14 @@ export const sortByOrder = (eventMap: Map<string, EventModel[]>, order: string[]
     : new Map(Array.from(eventMap.entries()).map(([key, value]) => [key, value.sort(compareOrder(0, order))]));
 };
 
-const compareOrder =
+export const compareOrder =
   (index: number, order: string[]) =>
   (a: EventModel, b: EventModel): number => {
     const desc = order[index].startsWith('-');
     const key = order[index].replace('-', '');
     const aValue = getComparableValue(a.getData(key));
     const bValue = getComparableValue(b.getData(key));
-    if (aValue === bValue) return order[index + 1] ? compareOrder(index + 1, order)(a, b) : 0;
+    if (isEqualValue(aValue, bValue)) return order[index + 1] ? compareOrder(index + 1, order)(a, b) : 0;
     if (aValue == null) return 1;
     if (bValue == null) return -1;
     if (aValue > bValue) return desc ? -1 : 1;
@@ -59,4 +59,9 @@ const compareOrder =
 const getComparableValue = <T>(value: T): T | DateTime<true> => {
   const date = DateTime.fromISO(`${value}`);
   return date.isValid ? date : value;
+};
+
+const isEqualValue = (a: unknown, b: unknown): boolean => {
+  if (a instanceof DateTime && b instanceof DateTime) return a.equals(b);
+  return a === b;
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './dateUtils';
+export * from './utils';

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,0 +1,17 @@
+export const fillStartWithValue = <T>(arr: (T | undefined)[], value: T): (T | undefined)[] => {
+  if (arr.length === 0) return [value];
+
+  const emptyIndex = arr.findIndex(item => item == null);
+  if (emptyIndex !== -1) {
+    const newArr = [...arr];
+    newArr[emptyIndex] = value;
+    return newArr;
+  }
+
+  return [...arr, value];
+};
+
+export const getFillIndex = <T>(arr: (T | undefined)[]): number => {
+  const emptyIndex = arr.findIndex(item => item == null);
+  return emptyIndex !== -1 ? emptyIndex : arr.length;
+};


### PR DESCRIPTION
### EventInput interface에 index signature 추가
- 좀 더 유연한 event 관리가 가능하도록 Evendar에서 사용하는 값 외에 다른 속성을 추가할 수 있도록 `index signature`를 추가했습니다.
- `index signature`를 추가함에 따라 모든 속성이 허용 되므로 `order`의 타입을 `string[]`으로 수정했습니다.
<br>

### 날짜 비교 방식 수정
- 우선 순위 적용을 위해 값 비교를 하는 부분에서 값이 동일한지 확인하기 위해 `===(일치 연산자)`를 사용했는데, Date 타입의 경우 일치 연산자로는 같은 날짜(시간 포함)인지 확인이 불가능하므로 DateTime의 내장 함수를 활용하도록 수정했습니다.
<br>

### N일 일정 분할 관련 이슈 수정
- 잘못된 우선 순위 적용으로 인해 일부 일정 렌더링이 정상 동작하지 않는 이슈를 수정했습니다.
  - 기존에는 날짜 별 그룹화 시에 일정을 함께 push 했으나, 이 경우 미리 채워져 있는 일정들로 인해 우선 순위 적용이 잘못 이루어지는 이슈가 발생하여 그룹화 시에는 우선 순위에 따른 정렬만 적용하도록 수정했습니다.
- 일정 분할 시 잘못된 분할 로직으로 인해 일정 배치가 잘못 이루어지는 이슈를 수정했습니다.
  - 1일 일정인 경우 일정 배열을 앞에서부터 빈공간 없이 채우되 꽉 차있는 경우 가장 마지막에 삽입되도록 수정했습니다.
    - `fillStartWithValue(arr, value)`
  - N일(N > 1) 일정인 경우 일부 일정이 다른 일정과 겹쳐 렌더링되는 이슈가 있어 일정이 렌더링되는 날짜들 중 해당 일정이 위치할 수 있는 `가장 큰 index`에 일정을 삽입했습니다.
  - 2주 이상 걸쳐 있는 일정 렌더링 시에는 빈 공간 없이 위에서부터 채우기 위해 날짜 별로 그룹화하던 로직을 주 별 그룹화 하도록 수정했습니다.
<br>

### null(undefined) 참조 에러 수정
- N일 일정 일정 렌더링을 위해 event가 null(undefined)인 경우가 있는데, 해당 부분에서 null 참조 에러가 발생하여 수정했습니다.
<br>

### 더 보기 count 이슈 수정
- 더 보기 count 계산 시 일정 배치 로직으로 인해 빈 공간이 필요한 경우 빈 값이 할당되는데, 이 빈 값으로 인해 count가 잘못 계산되는 이슈를 수정했습니다.